### PR TITLE
Use deployment URI instead of Github URI for artifacts

### DIFF
--- a/solution_template/mainTemplate.json
+++ b/solution_template/mainTemplate.json
@@ -7,7 +7,7 @@
         "artifactsBaseUrl": "",
         "description": "Artifacts location"
       },
-      "defaultValue": "https://raw.githubusercontent.com/Azure/jenkins/master/solution_template/",
+      "defaultValue": "[uri(deployment().properties.templateLink.uri, '.')]",
       "type": "string"
     },
     "artifactsLocationSasToken": {


### PR DESCRIPTION
In Jenkins solution template CI job, failing to download install_jenkins.sh script occurs from time to time. Using solution template's script instead of download from Github again just as [ELK](https://github.com/Microsoft/elk-acs-kubernetes/blob/f098a56e6499316513adea5ea53f380e102b25e5/mainTemplate.json#L246) does.

```
 "code": "VMExtensionProvisioningError",
[SSH: false Storage Type: Premium_LRS Existing Public IP: true]         "message": "VM has reported a 
failure when processing extension 'Init'. Error message: \"Enable failed: processing file downloads failed: 
failed to download file[0]: failed to download file: http request failed: Get 
https://raw.githubusercontent.com/Azure/jenkins/master/solution_template//scripts/install_jenkins.sh: 
dial tcp 151.101.248.133:443: i/o timeout\"."
```