### PR TITLE
Change contraint for vnet address space

### DIFF
--- a/solution_template/createUiDefinition.json
+++ b/solution_template/createUiDefinition.json
@@ -116,7 +116,7 @@
               "addressPrefixSize": "/16"
             },
             "constraints": {
-              "minAddressPrefixSize": "/24"
+              "minAddressPrefixSize": "/30"
             },
             "subnets": {
               "subnet1": {


### PR DESCRIPTION
Change VNET address space prefix size constraint from 24 to 30, the same as the constraint for subnet. 