### PR TITLE
Fix principal not found issue

### DIFF
--- a/solution_template/mainTemplate.json
+++ b/solution_template/mainTemplate.json
@@ -446,7 +446,7 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2017-05-01",
       "dependsOn": [
-        "[resourceId('Microsoft.Resources/deployments', variables('vmDeploymentName'))]"
+        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('vmName'), 'Init')]"
       ],
       "condition": "[equals(parameters('spType'), 'managed-identities-for-azure-resources')]",
       "properties": {


### PR DESCRIPTION
When creating a role assignment with the VM system identity, it may throw  `PrincipalNotFound` exception. This may be because there is a gap between service principal creation or cache issue.  This issue occurs quite frequent recently. More discussion on Azure/azure-powershell#2286.

Change roleAssignments method depending from vm deployment to init scripts which takes several minutes to temporarily migrate this issue.