### PR TITLE
fix(az-storage-account-credentials): Rename AzureCredentials to AzureStorageAccount

### DIFF
--- a/solution_template/scripts/install_jenkins.sh
+++ b/solution_template/scripts/install_jenkins.sh
@@ -396,7 +396,7 @@ fi
 
 #generate storage credential
 storage_cred=$(cat <<EOF
-<com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials plugin="windows-azure-storage">
+<com.microsoftopentechnologies.windowsazurestorage.helper.AzureStorageAccount plugin="windows-azure-storage">
   <scope>GLOBAL</scope>
   <id>artifact_storage</id>
   <description>The storage credential for artifact manager</description>
@@ -405,7 +405,7 @@ storage_cred=$(cat <<EOF
     <storageAccountKey>${storage_key}</storageAccountKey>
     <blobEndpointURL>${storage_endpoint}</blobEndpointURL>
   </storageData>
-</com.microsoftopentechnologies.windowsazurestorage.helper.AzureCredentials>
+</com.microsoftopentechnologies.windowsazurestorage.helper.AzureStorageAccount>
 EOF
 )
 


### PR DESCRIPTION
Due to a change on [windows-azure-storage](https://plugins.jenkins.io/windows-azure-storage/) plugin (since version **1.1.1**), XML credential has to be adapted:
* Related [commit](https://github.com/jenkinsci/windows-azure-storage-plugin/commit/1253e0060cca261b0c1433ef419f8ba8a5eb5d1d) about this change
* **AzureCredentials** has to be renamed to **AzureStorageAccount**

This change will fix the issue when people wants to install [Jenkins from Azure marketplace](https://docs.microsoft.com/en-us/azure/developer/jenkins/configure-on-linux-vm) by specifying information to enable Azure Artifacts Manager.
