### PR TITLE
Add new gpg key use to sign Jenkins package

### DIFF
--- a/solution_template/scripts/install_jenkins.sh
+++ b/solution_template/scripts/install_jenkins.sh
@@ -280,6 +280,7 @@ EOF
 
 #update apt repositories
 wget -q -O - https://pkg.jenkins.io/debian/jenkins-ci.org.key | sudo apt-key add -
+wget -q -O - https://pkg.jenkins.io/debian/jenkins.io.key | sudo apt-key add -
 
 if [ "$jenkins_release_type" == "weekly" ]; then
   sudo sh -c 'echo deb http://pkg.jenkins.io/debian binary/ > /etc/apt/sources.list.d/jenkins.list'


### PR DESCRIPTION
The gpg key used to sign Jenkins packages was updated on 16th of April 2020, therefore you need to reimport it if you imported before this date.

I have left the old key import as well in case it used elsewhere.

See: https://pkg.jenkins.io/debian/